### PR TITLE
Add the FocusSerial plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -175,3 +175,6 @@
 [submodule "avr/libraries/Kaleidoscope-Hardware-Technomancy-Atreus"]
 	path = avr/libraries/Kaleidoscope-Hardware-Technomancy-Atreus
 	url = https://github.com/keyboardio/Kaleidoscope-Hardware-Technomancy-Atreus.git
+[submodule "avr/libraries/Kaleidoscope-FocusSerial"]
+	path = avr/libraries/Kaleidoscope-FocusSerial
+	url = https://github.com/keyboardio/Kaleidoscope-FocusSerial.git


### PR DESCRIPTION
This depends on keyboardio/Kaleidoscope#362, and is a pre-requirement for updating current Focus-using plugins to the new APIs.