### PR TITLE
boards.txt: Add default extra_flags for Atreus

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -114,6 +114,9 @@ atreus.pid.0=0xa1e5
 
 atreus.upload.maximum_data_size=2560
 
+## defaults
+atreus.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Technomancy-Atreus.h"' -DKALEIDOSCOPE_HARDWARE_ATREUS_PINOUT_ASTAR=1
+
 atreus.menu.cpu.astar=A*
 atreus.menu.cpu.astar.upload.tool=avrdude
 atreus.menu.cpu.astar.upload.protocol=avr109


### PR DESCRIPTION
Not having a default means that arduino-builder will not use any extra flags. With the default set to the same as the Post-2016 PCB (the most recent one), the Atreus example in Kaleidoscope will compile again.
