### PR TITLE
Drop the Kaleidoscope-Hardware library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -22,9 +22,6 @@
 [submodule "avr/libraries/Model01-Firmware"]
 	path = avr/libraries/Model01-Firmware
 	url = https://github.com/Keyboardio/Model01-Firmware
-[submodule "avr/libraries/Kaleidoscope-Hardware"]
-	path = avr/libraries/Kaleidoscope-Hardware
-	url = https://github.com/Keyboardio/Kaleidoscope-Hardware
 [submodule "avr/libraries/Kaleidoscope-HIDAdaptor-KeyboardioHID"]
 	path = avr/libraries/Kaleidoscope-HIDAdaptor-KeyboardioHID
 	url = https://github.com/keyboardio/Kaleidoscope-HIDAdaptor-KeyboardioHID


### PR DESCRIPTION
The library is being superseded by a hardware base class in Kaleidoscope itself. As it is not used anywhere, and served only documentation purposes, remove it.
