### PR TITLE
Fix link order problems with inter-library/inter-plugin dependencies

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -22,6 +22,7 @@ compiler.path={runtime.tools.avr-gcc.path}/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD
 compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--gc-sections
+compiler.c.elf.flags_join_archives=rcT
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp
 compiler.cpp.cmd=avr-g++
@@ -64,8 +65,21 @@ recipe.S.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.S.flags} -mmcu={b
 archive_file_path={build.path}/{archive_file}
 recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compiler.ar.extra_flags} "{archive_file_path}" "{object_file}"
 
-## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" {object_files} "{build.path}/{archive_file}" "-L{build.path}" -lm
+################################################################################
+## PLEASE NOTE: The way we link our elf binary significantly differs from the 
+##              way that Arduino handles things by default. 
+##              The original linker command has been split up into two 
+##              steps (recipe.c.combine.pattern and recipe.hooks.linking.postlink.1.pattern).
+##              This is necessary to prevent link errors reporting unresolved symbols
+##              due to order dependencies of libraries and objects appearing
+##              in the linker command line.
+##              
+## CHANGED WRT DEFAULT: Generate a large .a archive to prevent link order issues with garbage collection
+recipe.c.combine.pattern="{compiler.path}/{compiler.ar.cmd}" {compiler.c.elf.flags_join_archives} "{build.path}/{build.project_name}_joined.a" {object_files} "{build.path}/{archive_file}"
+##
+## NEWLY INTRODUCED: Link with garbage collection
+recipe.hooks.linking.postlink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} -mmcu={build.mcu} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}_joined.a" "-L{build.path}" -lm
+################################################################################
 
 ## Create output files (.eep and .hex)
 recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"


### PR DESCRIPTION
Before this change, when Arduino was linking the elf binary, it added all
objects and archives (libraries/plugins) to a long linker command line.
This would sometimes cause issues due to the linker's gargabe collection feature.
When one library A referenced a symbol from a library B but library A appeared after B
in the linker command line, the referenced symbol was in some cases garbage
collected as to the linker it appeared to be unreferenced.

To understand this better it is important to know that the linker processes
objects and archives one by one in the order of their appearance at the command
line. For every object or archive encountered it runs garbage collection individually.
That's why symbols might get discarded although an object or archives that is
encountered later on while processing the linker command line might have referenced it.

To fix this problem this commit divides up the linker process into two steps.

First, all objects and archives are combined in a large .a archive. Then, this
archive is passed to the original linker command line, thereby replacing the
original set of objects and archives.

The final link now sees all symbols together. Thus, it is able to determine the true
interdependencies and do a proper garbage collection without accidentally
generating unresolved symbols.

With this fix, the order of appearance of include directives in the sketch file that formerly had an
influence on the link order (as Arduino passes library archives to the linker in
the order of the appearance of the matching includes in the sketch),
can now be savely chosen arbitrarily.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>