### PR TITLE
Fixed build errors with follow up builds after a failed attempt to link

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -74,6 +74,11 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 ##              This is necessary to prevent link errors reporting unresolved symbols
 ##              due to order dependencies of libraries and objects appearing
 ##              in the linker command line.
+##
+## CHANGED WRT DEFAULT: Remove a pre-existing joined library. This is necessary if the library was not
+##                    removed at the end of a previous build, because the build process
+##                    terminated early after a failed attempt to link (e.g. because of missing symbols).
+recipe.hooks.linking.prelink.1.pattern={tools.rm_start.cmd} "{build.path}/{build.project_name}_joined.a" {tools.rm_end.cmd}
 ##              
 ## CHANGED WRT DEFAULT: Generate a large .a archive to prevent link order issues with garbage collection
 recipe.c.combine.pattern="{compiler.path}/{compiler.ar.cmd}" {compiler.c.elf.flags_join_archives} "{build.path}/{build.project_name}_joined.a" {object_files} "{build.path}/{archive_file}"
@@ -86,7 +91,7 @@ recipe.hooks.linking.postlink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" {c
 ##                   would otherwise result when updating a pre-existing
 ##                   joined archive file during a subsequent firmware build.
 ##
-recipe.hooks.linking.postlink.2.pattern={tools.rm.cmd} "{build.path}/{build.project_name}_joined.a"
+recipe.hooks.linking.postlink.2.pattern={tools.rm_start.cmd} "{build.path}/{build.project_name}_joined.a" {tools.rm_end.cmd}
 ################################################################################
 
 ## Create output files (.eep and .hex)
@@ -149,8 +154,23 @@ tools.dfu-programmer.upload.params.quiet=
 tools.dfu-programmer.upload.noverify=
 tools.dfu-programmer.upload.pattern=/bin/sh -c '"{cmd.path}" atmega32u4 erase && "{cmd.path}" atmega32u4 flash "{build.path}/{build.project_name}.hex" && "{cmd.path}" atmega32u4 start'
 
-tools.rm.cmd=rm -f
-tools.rm.cmd.windows=powershell.exe Remove-Item -LiteralPath
+# Unlike rm on Unix-like systems, powershell's 'rm' command does not ignore non existing files
+# and terminates in error when the file that is to be removed cannot be found.
+# This would result in a premature termination of the overall build process that
+# must be prevented.
+#
+# To allow for possibly non-existing files being passed to command 'rm' we force 
+# powershell to ignore the resulting error and pass error value zero
+# back to the build system. 
+#
+# For this to work, the rm-command is split up in two
+# parts (start/end). The second (end) part is only required on Windows.
+#
+tools.rm_start.cmd=rm -f
+tools.rm_end.cmd=
+
+tools.rm_start.cmd.windows=powershell.exe rm -ErrorAction SilentlyContinue -LiteralPath
+tools.rm_end.cmd.windows= ; exit 0
 
 # USB Default Flags
 # Default blank usb manufacturer will be filled in at compile time


### PR DESCRIPTION
In rare occasions during development when e.g. a missing symbol caused
the linker process to abort, the joined library was not removed
at the end of the build. In subsequent builds this possibly
caused problems during creation of the joined library as a
static library cannot be updated but must be removed and re-created.

This change solves the described problem by removing a possibly
pre-exising joined library before the link.

This is tested to work on Windows and Linux. Only the Windows part actually changed, so macOS should be fine, too.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>