### PR TITLE
Removed the redundant HID library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,9 +13,6 @@
 [submodule "avr/libraries/KeyboardioHID"]
 	path = avr/libraries/KeyboardioHID
 	url = https://github.com/keyboardio/KeyboardioHID
-[submodule "avr/libraries/HID"]
-	path = avr/libraries/HID
-	url = https://github.com/keyboardio/Arduino-HID
 [submodule "avr/libraries/Kaleidoscope"]
 	path = avr/libraries/Kaleidoscope
 	url = https://github.com/keyboardio/Kaleidoscope


### PR DESCRIPTION
The two contained c++ files are almost identical to those
in KeyboardioHID.

The HID library is not used by the build. Checks prove that two
firmware binaries build with and without the library are identical.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>