### PR TITLE
Adds build recipe to paste header/footer to sketch

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -188,3 +188,16 @@ tools.ctags.path={runtime.tools.ctags.path}
 tools.ctags.cmd.path={path}/ctags
 tools.ctags.pattern="{cmd.path}" -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives "{source_file}"
 
+# The following recipes enable adding code to specific places
+# of the preprocessed firmware sketch. This is done by pasting 
+# the content of two files
+#   kaleidoscope_internal/sketch_preprocessing/sketch_header.h,
+#   kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
+# to the top and the bottom of the preprocessed sketch file.
+
+recipe.hooks.sketch.prebuild.1.pattern=mv "{build.path}/sketch/{build.project_name}.cpp" "{build.path}/sketch/{build.project_name}.cpp.bak"
+recipe.hooks.sketch.prebuild.2.pattern=sh -c "cat {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h {build.path}/sketch/{build.project_name}.cpp.bak {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h > {build.path}/sketch/{build.project_name}.cpp"
+
+recipe.hooks.sketch.prebuild.1.pattern.windows={tools.rm_start.cmd} "{build.path}/sketch/{build.project_name}.cpp.bak" {tools.rm_end.cmd}
+recipe.hooks.sketch.prebuild.2.pattern.windows=powershell.exe mv "{build.path}/sketch/{build.project_name}.cpp" "{build.path}/sketch/{build.project_name}.cpp.bak"
+recipe.hooks.sketch.prebuild.3.pattern.windows=powershell.exe -command "& {&cat {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h, {build.path}/sketch/{build.project_name}.cpp.bak, {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h | sc {build.path}/sketch/{build.project_name}.cpp}"

--- a/virtual/platform.txt
+++ b/virtual/platform.txt
@@ -168,3 +168,17 @@ tools.rm_end.cmd.windows= ; exit 0
 # - from numeric vendor ID, set to Unknown otherwise
 build.usb_manufacturer="Unknown"
 build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'
+
+# The following recipes enable adding code to specific places
+# of the preprocessed firmware sketch. This is done by pasting 
+# the content of two files
+#   kaleidoscope_internal/sketch_preprocessing/sketch_header.h,
+#   kaleidoscope_internal/sketch_preprocessing/sketch_footer.h
+# to the top and the bottom of the preprocessed sketch file.
+
+recipe.hooks.sketch.prebuild.1.pattern=mv "{build.path}/sketch/{build.project_name}.cpp" "{build.path}/sketch/{build.project_name}.cpp.bak"
+recipe.hooks.sketch.prebuild.2.pattern=sh -c "cat {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h {build.path}/sketch/{build.project_name}.cpp.bak {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h > {build.path}/sketch/{build.project_name}.cpp"
+
+recipe.hooks.sketch.prebuild.1.pattern.windows={tools.rm_start.cmd} "{build.path}/sketch/{build.project_name}.cpp.bak" {tools.rm_end.cmd}
+recipe.hooks.sketch.prebuild.2.pattern.windows=powershell.exe mv "{build.path}/sketch/{build.project_name}.cpp" "{build.path}/sketch/{build.project_name}.cpp.bak"
+recipe.hooks.sketch.prebuild.3.pattern.windows=powershell.exe -command "& {&cat {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_header.h, {build.path}/sketch/{build.project_name}.cpp.bak, {runtime.platform.path}/libraries/Kaleidoscope/src/kaleidoscope_internal/sketch_preprocessing/sketch_footer.h | sc {build.path}/sketch/{build.project_name}.cpp}"

--- a/virtual/platform.txt
+++ b/virtual/platform.txt
@@ -169,6 +169,14 @@ tools.rm_end.cmd.windows= ; exit 0
 build.usb_manufacturer="Unknown"
 build.usb_flags=-DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'
 
+# ctags configuration
+# Remove from the Arduino core in 1.8.10.
+# Jesse isn't sure why arduino removed it, but adding it here for now to unbreak builds
+# ------------------------------
+tools.ctags.path={runtime.tools.ctags.path}
+tools.ctags.cmd.path={path}/ctags
+tools.ctags.pattern="{cmd.path}" -u --language-force=c++ -f - --c++-kinds=svpf --fields=KSTtzns --line-directives "{source_file}"
+
 # The following recipes enable adding code to specific places
 # of the preprocessed firmware sketch. This is done by pasting 
 # the content of two files


### PR DESCRIPTION
**Important:** Only merge this it/after https://github.com/keyboardio/Kaleidoscope/pull/763 has been merged and pull up the bundle afterwards. Otherwise build errors will result.

This change adds a build recipe that pastes a header and footer include to the preprocessed sketch file.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>