### PR TITLE
Added map file creation

### DIFF
--- a/avr/platform.txt
+++ b/avr/platform.txt
@@ -22,7 +22,7 @@ compiler.path={runtime.tools.avr-gcc.path}/bin/
 #compiler.path=/usr/bin/
 compiler.c.cmd=avr-gcc
 compiler.c.flags=-c -g -Os {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD
-compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--gc-sections
+compiler.c.elf.flags={compiler.warning_flags} -Os -Wl,--gc-sections "-Wl,-Map={build.path}/{build.project_name}.elf.map"
 compiler.c.elf.flags_join_archives=rcT
 compiler.c.elf.cmd=avr-gcc
 compiler.S.flags=-c -g -x assembler-with-cpp

--- a/virtual/platform.txt
+++ b/virtual/platform.txt
@@ -17,7 +17,7 @@ compiler.warning_flags.all=-Wall -Wextra
 compiler.path=
 compiler.c.cmd=gcc
 compiler.c.flags=-c -g {compiler.warning_flags} -std=gnu11 -ffunction-sections -fdata-sections -MMD -DKALEIDOSCOPE_VIRTUAL_BUILD=1 -DKEYBOARDIOHID_BUILD_WITHOUT_HID=1 -DUSBCON=dummy -DARDUINO_ARCH_AVR=1
-compiler.c.elf.flags={compiler.warning_flags} -Wl,--gc-sections
+compiler.c.elf.flags={compiler.warning_flags} -Wl,--gc-sections "-Wl,-Map={build.path}/{build.project_name}.elf.map"
 compiler.c.elf.flags_join_archives=rcT
 compiler.c.elf.cmd=g++
 compiler.S.flags=-c -g -x assembler-with-cpp


### PR DESCRIPTION
A linker .map file will be created as an additional build artifact.
This map file can be used for debugging symbol issues or for
firmware post-processing.

Signed-off-by: Florian Fleissner <florian.fleissner@inpartik.de>