### PR TITLE
Travis CI fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ sudo: false
 os:
 - linux
 install:
-- mkdir -p hardware/
-- ln -s `pwd` hardware/keyboardio
+- mkdir -p ../hardware/
+- ln -s `pwd` ../hardware/keyboardio
 script:
-- make travis-test-all BOARD_HARDWARE_PATH=$(pwd)/hardware
+- make travis-test-all BOARD_HARDWARE_PATH=$(pwd)/../hardware
 branches:
   except:
   - gh-pages
@@ -20,7 +20,7 @@ notifications:
   email:
     on_success: change
     on_failure: change
-cache: 
+cache:
   ccache: true
   directories:
     - .ccache


### PR DESCRIPTION
This fixes the build issues on Travis, in two parts:

- First we move the `hardware` directory outside of the cloned dir, so that Arduino can find it. No clue why it doesn't find it inside, but it works outside, so I'm happy.
- We update the `build-tools` submodule, where I pushed a small verbosity fix to master. Without being verbose, Travis will time us out due to no output for 10+ minutes.

These two together fix #27.