### PR TITLE
Set the Keyboardio Atreus' power draw to 25ma

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -162,7 +162,7 @@ atreus2.pid.0=0x2303
 atreus2.upload.maximum_data_size=2560
 
 ## defaults
-atreus2.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Technomancy-Atreus2.h"'
+atreus2.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Technomancy-Atreus2.h"' -DUSB_CONFIG_POWER=(25)
 atreus2.build.mcu=atmega32u4
 atreus2.build.f_cpu=16000000L
 atreus2.build.vid=0x1209


### PR DESCRIPTION
The Keyboardio Atreus does not have any LEDs, and only needs 25ma to operate. Lets set `USB_CONFIG_POWER` to that, so we draw less power, and as a consequence, work better with mobile devices.
