### PR TITLE
Generate virtual/boards.txt from avr/boards.txt instead of linking them

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 arduino-*-linux64.tar.xz
 arduino-*
+/virtual/boards.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
 - mkdir -p ../hardware/
 - ln -s `pwd` ../hardware/keyboardio
 script:
+- make prepare-virtual
 - make travis-test-all BOARD_HARDWARE_PATH=$(pwd)/../hardware
 branches:
   except:

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ KALEIDOSCOPE_BUILDER_DIR ?= ./avr/libraries/Kaleidoscope/bin/
 
 endif
 
+prepare-virtual:
+	sed -e "s/\(.*\)\.build\.core=arduino:arduino/\1.build.core=keyboardio:arduino/" avr/boards.txt >virtual/boards.txt
+
 update-submodules: checkout-submodules
 	@echo "All Kaleidoscope libraries have been updated from GitHub"
 

--- a/virtual/boards.txt
+++ b/virtual/boards.txt
@@ -1,1 +1,0 @@
-../avr/boards.txt


### PR DESCRIPTION
When building the virtual boards, we want to have the base core as `keyboardio:arduino`, instead of `arduino:arduino`, because we provide the base ourselves. To this end, instead of symlinking `avr/boards.txt` and `virtual/boards.txt`, generate the latter from the former.

Once we have other architectures, such as SAMD, we can concat all the boards.txt files and do the same `base.core` replacements.

This is a pre-requisite for keyboardio/Kaleidoscope#851.
