### PR TITLE
Merge epan/build/justlib into master

### DIFF
--- a/virtual/cores/arduino/virtual_io.cpp
+++ b/virtual/cores/arduino/virtual_io.cpp
@@ -55,7 +55,7 @@ bool initVirtualInput(int argc, char* argv[]) {
   if (argc < 2 || strcmp(argv[1], "?") == 0) {
     printHelp();
     return false;
-  } else if (argc > 2) {
+  } else if (argc > 3) {
     std::cerr << "Error: more arguments than expected (got " << (argc - 1) << ")" << std::endl;
     return false;
   }
@@ -74,12 +74,15 @@ bool initVirtualInput(int argc, char* argv[]) {
     }
   }
 
-  if (mkdir("results", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) && errno != EEXIST) {
-    std::cerr << "Error creating directory 'results', errno " << errno << std::endl;
-    return false;
+  if (argc > 2 && strcmp(argv[2], "-q") != 0) {
+    std::cerr << "Error: ignoring unknown argument '" << argv[2] << "'" << std::endl;
+    if (mkdir("results", S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) && errno != EEXIST) {
+      std::cerr << "Error creating directory 'results', errno " << errno << std::endl;
+      return false;
+    }
+    usbstream = new std::ofstream("results/USB.txt");
+    ledstream = new std::ofstream("results/LED.txt");
   }
-  usbstream = new std::ofstream("results/USB.txt");
-  ledstream = new std::ofstream("results/LED.txt");
 
   return true;
 }
@@ -99,10 +102,11 @@ std::string getLineOfInput(bool anythingHeld) {
 void printHelp(void) {
   std::cout << "\nUsage:\n" << std::endl;
   std::cout << "(Running with no arguments or with the argument '?' will print this help message and quit.)\n" << std::endl;
-  std::cout << "This program expects a single argument, which is either:" << std::endl;
+  std::cout << "This program expects either one or two arguments, which must be one of:" << std::endl;
   std::cout << "  1. An input file/script, with format given below, or" << std::endl;
   std::cout << "  2. \"-i\", to run interactively, where you can interactively enter commands and see results." << std::endl;
   std::cout << "  3. \"-t\", to run a test function that is specified in the sketch file." << std::endl;
+  std::cout << "  4. \"-t -q\", to run tests quietly (suppressing `results/` output streams)." << std::endl;
   std::cout << "\nIn either case, for each scan cycle you will specify zero or more input 'commands', that is," << std::endl;
   std::cout << "  actions to take on the keys of the virtual keyboard.  Each line of the input file, or each" << std::endl;
   std::cout << "  prompt (in interactive mode), represents one scan cycle; a blank line or empty prompt means" << std::endl;

--- a/virtual/cores/arduino/virtual_io.cpp
+++ b/virtual/cores/arduino/virtual_io.cpp
@@ -55,9 +55,6 @@ bool initVirtualInput(int argc, char* argv[]) {
   if (argc < 2 || strcmp(argv[1], "?") == 0) {
     printHelp();
     return false;
-  } else if (argc > 3) {
-    std::cerr << "Error: more arguments than expected (got " << (argc - 1) << ")" << std::endl;
-    return false;
   }
 
   if (strcmp(argv[1], "-i") == 0) {

--- a/virtual/platform.txt
+++ b/virtual/platform.txt
@@ -74,36 +74,9 @@ recipe.ar.pattern="{compiler.path}{compiler.ar.cmd}" {compiler.ar.flags} {compil
 ##              due to order dependencies of libraries and objects appearing
 ##              in the linker command line.
 ##
-## CHANGED WRT DEFAULT: Remove a pre-existing joined library. This is necessary if the library was not
-##                    removed at the end of a previous build, because the build process
-##                    terminated early after a failed attempt to link (e.g. because of missing symbols).
-recipe.hooks.linking.prelink.1.pattern={tools.rm_start.cmd} "{build.path}/{build.project_name}_joined.a" {tools.rm_end.cmd}
-##
-## CHANGED WRT DEFAULT: Generate a large .a archive to prevent link order issues with garbage collection
-recipe.c.combine.pattern="{compiler.path}/{compiler.ar.cmd}" {compiler.c.elf.flags_join_archives} "{build.path}/{build.project_name}_joined.a" {object_files} "{build.path}/{archive_file}"
-##
-## NEWLY INTRODUCED: Link with global garbage collection (considering all
-##                   objects and libraries together).
-recipe.hooks.linking.postlink.1.pattern="{compiler.path}{compiler.c.elf.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -o "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}_joined.a" "-L{build.path}" -lm {compiler.ldflags}
-##
-## NEWLY INTRODUCED: Removing the joined library is required to avoid malformed archives that
-##                   would otherwise result when updating a pre-existing
-##                   joined archive file during a subsequent firmware build.
-##
-recipe.hooks.linking.postlink.2.pattern={tools.rm_start.cmd} "{build.path}/{build.project_name}_joined.a" {tools.rm_end.cmd}
+## CHANGED WRT DEFAULT: Generate a large .a archive to be linked higher up in the build system.
+recipe.c.combine.pattern="{compiler.path}/{compiler.ar.cmd}" {compiler.c.elf.flags_join_archives} "{build.path}/{build.project_name}.a" {object_files} "{build.path}/{archive_file}"
 ################################################################################
-
-# Run the test executable as a build step
-#
-recipe.hooks.linking.postlink.3.pattern="{build.path}/{build.project_name}.elf" -t
-
-## Create output files (.eep and .hex)
-recipe.objcopy.eep.pattern="{compiler.path}{compiler.objcopy.cmd}" {compiler.objcopy.eep.flags} {compiler.objcopy.eep.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.eep"
-recipe.objcopy.hex.pattern="{compiler.path}{compiler.elf2hex.cmd}" {compiler.elf2hex.flags} {compiler.elf2hex.extra_flags} "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.hex"
-
-## Save hex
-recipe.output.tmp_file={build.project_name}.hex
-recipe.output.save_file={build.project_name}.{build.variant}.hex
 
 ## Compute size
 recipe.size.pattern=echo "[size not computed for virtual build]"


### PR DESCRIPTION
This only affects the virtual build.  That said, it will completely break things if `keyboardio/Kaleidoscope:epan/testing/main` isn't merged at the same time.  The point is that the latter depends on the configuration provided by the former, and the configuration provided by the former will break virtual builds on any other branch of `keyboardio:Kaleidoscope` until `epan/testing/main` is merged.  This PR draft is here for discussion and potentially future action.