### PR TITLE
avr/boards: Add a compiler flag for the model01 to set the TWI buffer…

### DIFF
--- a/avr/boards.txt
+++ b/avr/boards.txt
@@ -42,7 +42,7 @@ model01.build.core=arduino:arduino
 model01.build.variant=model01
 model01.build.flashing_instructions="To update your keyboard's firmware, hold down the 'Prog' key on your keyboard.\n\n(When the 'Prog' key glows red, you can release it.)"
 # TODO - the hardware spec / hardware duplication here makes Jesse unhappy. he would not like to see it live here long-term
-model01.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Model01.h"'
+model01.build.extra_flags={build.usb_flags} '-DKALEIDOSCOPE_HARDWARE_H="Kaleidoscope-Hardware-Model01.h"' -DTWI_BUFFER_LENGTH=32
 
 
 ##############################################################


### PR DESCRIPTION
… size

With a recent change in Kaleidoscope, the `kaleidoscope::driver::keyboardio::Model01Side` driver now uses the twi implementation also used by the Keyboardio Imago. This sets the default buffer length to 192, and we need to override that here.

We need the override here, because it is used by `twi.c`, so it needs to be defined when compiling said file in isolation.

The practical consequence of this is that Model01 builds will use 160 bytes less SRAM with this change.