### PR TITLE
Add a DebugStdout "Serial" device to the virtual core as a debugging …

### DIFF
--- a/virtual/cores/arduino/HardwareSerial.cpp
+++ b/virtual/cores/arduino/HardwareSerial.cpp
@@ -1,6 +1,14 @@
 #include "HardwareSerial.h"
 #include "Arduino.h"
 
+#undef min
+#undef max
+
+#include "Stream.h"
+#include <stdio.h>
+#include <iostream>
+
+
 // see comments in the real HardwareSerial.cpp
 void serialEvent() __attribute__((weak));
 void serialEvent1() __attribute__((weak));
@@ -72,7 +80,17 @@ int HardwareSerial::available(void) {
   return 0;
 }
 
+
+size_t DebugStderrSerial::write(uint8_t c) {
+   std::cerr << c ; 
+  return 1;
+}
+
+
 HardwareSerial Serial;
 HardwareSerial Serial1;
 HardwareSerial Serial2;
 HardwareSerial Serial3;
+
+DebugStderrSerial DebugStderr;
+

--- a/virtual/cores/arduino/HardwareSerial.h
+++ b/virtual/cores/arduino/HardwareSerial.h
@@ -38,6 +38,13 @@ class HardwareSerial : public Stream {
   static unsigned serialNumber;
   FILE* out;
 };
+
+class DebugStderrSerial : public HardwareSerial  {
+  public:
+  virtual size_t write(uint8_t);
+  using Print::write;  // write(str) and write(buf, size)
+};
+
 // The default Arduino core only provides each of these HardwareSerial objects if
 // various things are #defined.  We always provide them for virtual hardware.
 extern HardwareSerial Serial;
@@ -48,6 +55,10 @@ extern HardwareSerial Serial2;
 #define HAVE_HWSERIAL2
 extern HardwareSerial Serial3;
 #define HAVE_HWSERIAL3
+
+extern DebugStderrSerial DebugStderr;
+
+
 // end HardwareSerial
 
 extern void serialEventRun(void) __attribute__((weak));


### PR DESCRIPTION
…affordance for developers.

DebugStdout works like a serial port, but allows print-statement debugging when running on our simulator (in a way that will not interfere with 'regular' uses of the Serial API.

Specifically, I expect this to be useful with tools like https://github.com/bblanchon/ArduinoTrace