### PR TITLE
The initialisation for ARDUINOTRACE_INIT uses DebugStderr, since

### DIFF
--- a/virtual/cores/arduino/HardwareSerial.cpp
+++ b/virtual/cores/arduino/HardwareSerial.cpp
@@ -92,5 +92,8 @@ HardwareSerial Serial1;
 HardwareSerial Serial2;
 HardwareSerial Serial3;
 
-DebugStderrSerial DebugStderr;
+DebugStderrSerial& DebugStderr() {
+  static DebugStderrSerial* ans = new DebugStderrSerial();
+  return *ans;
+}
 

--- a/virtual/cores/arduino/HardwareSerial.h
+++ b/virtual/cores/arduino/HardwareSerial.h
@@ -56,7 +56,7 @@ extern HardwareSerial Serial2;
 extern HardwareSerial Serial3;
 #define HAVE_HWSERIAL3
 
-extern DebugStderrSerial DebugStderr;
+extern DebugStderrSerial DebugStderr();
 
 
 // end HardwareSerial


### PR DESCRIPTION
these are globals defined in different translation units their initialisation order is not defined. In my case they initialised the wrong way around which triggered the UBSAN warning.

FWIW I got rid of the warning using the below use of the C++ FAQ suggestion https://isocpp.org/wiki/faq/ctors#static-init-order-on-first-use

Fixes Kaleidoscope#1348

Depends on Kaleidoscope #1349