### PR TITLE
also handle ZLP in USB_Recv

### DIFF
--- a/avr/cores/keyboardio/USBCore.cpp
+++ b/avr/cores/keyboardio/USBCore.cpp
@@ -245,6 +245,10 @@ int USB_Recv(u8 ep, void* d, int len)
 	
 	LockEP lock(ep);
 	u8 n = FifoByteCount();
+	if (!n && HasOUT()) {
+		ReleaseRX(); // handle ZLP
+		n = FifoByteCount();
+	}
 	len = min(n,len);
 	n = len;
 	u8* dst = (u8*)d;


### PR DESCRIPTION
The fix in https://github.com/arduino/Arduino/pull/6886 is incomplete. `USB_Recv` also needs to handle ZLPs.